### PR TITLE
Update main.js to use webpack5

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,9 @@ const path = require("path");
 const toPath = _path => path.join(process.cwd(), _path);
 
 module.exports = {
+  core: {
+    builder: "@storybook/builder-webpack5"
+    },
     stories: [
         "../src/**/*.stories.mdx",
         "../src/**/*.stories.@(js|jsx|ts|tsx)",
@@ -10,6 +13,7 @@ module.exports = {
         "@storybook/addon-links",
         "@storybook/addon-essentials",
         "@storybook/preset-create-react-app",
+        "@chakra-ui/storybook-addon"
     ],
     typescript: {
         reactDocgen: "react-docgen-typescript",


### PR DESCRIPTION
First of all you made an amazing [youtube video tutorial](https://www.youtube.com/watch?v=NZQTHgkGaBU&list=PLtIU0BH0pkKpiXrwbbQ1inAkAncZv3HF7&index=7)! I can't thank you enough for putting in the time to do this for your viewers. It's beyond helpful. 

I propose a quick fix in the main.js file so the build doesn't break for future viewers.

As of June 24, maybe earlier not sure, the storybook build breaks with the original main.js code. 
I specified to use webpack5, and that fixed it.

Err with original code was ** WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.**

I also added the  "@chakra-ui/storybook-addon" so that storybook recognizes the styling of chakra UI. Without it storybook shows an unstyled button.

I hope you continue making videos, they're really helpful. Thanks again!!